### PR TITLE
Added missing self argument for make_ellipse_path().

### DIFF
--- a/src/unicorn/svg_parser.py
+++ b/src/unicorn/svg_parser.py
@@ -147,7 +147,7 @@ class SvgEllipse(SvgPath):
     rx = float(node.get('rx','0'))
     ry = float(node.get('ry','0'))
     SvgPath.load(self,self.make_ellipse_path(rx,ry,node), mat)
-  def make_ellipse_path(rx, ry, node):
+  def make_ellipse_path(self, rx, ry, node):
     if rx == 0 or ry == 0:
       return None
     cx = float(node.get('cx','0'))


### PR DESCRIPTION
Parsing an SVG file with an ellipse gives the following error:

```
Traceback (most recent call last):
  File "unicorn.py", line 108, in <module>
    e.affect()
  File "/Applications/Inkscape.app/Contents/Resources/share/inkscape/extensions/inkex.py", line 268, in affect
    self.effect()
  File "unicorn.py", line 102, in effect
    parser.parse()
  File "/Users/jsc/.config/inkscape/extensions/unicorn/svg_parser.py", line 231, in parse
    self.recursivelyTraverseSvg(self.svg, [[1.0, 0.0, -(self.svgWidth/2.0)], [0.0, -1, (self.svgHeight/2.0)]])
  File "/Users/jsc/.config/inkscape/extensions/unicorn/svg_parser.py", line 266, in recursivelyTraverseSvg
    self.recursivelyTraverseSvg(node, matNew, parent_visibility = v)
  File "/Users/jsc/.config/inkscape/extensions/unicorn/svg_parser.py", line 266, in recursivelyTraverseSvg
    self.recursivelyTraverseSvg(node, matNew, parent_visibility = v)
  File "/Users/jsc/.config/inkscape/extensions/unicorn/svg_parser.py", line 290, in recursivelyTraverseSvg
    entity = self.make_entity(node, matNew)
  File "/Users/jsc/.config/inkscape/extensions/unicorn/svg_parser.py", line 304, in make_entity
    entity.load(node,mat)
  File "/Users/jsc/.config/inkscape/extensions/unicorn/svg_parser.py", line 149, in load
    SvgPath.load(self,self.make_ellipse_path(rx,ry,node), mat)
TypeError: make_ellipse_path() takes exactly 3 arguments (4 given)
```

This is due to a missing self argument in make_ellipse_path.
